### PR TITLE
fix(docs): Fix typo

### DIFF
--- a/pages/features/additional-hooks.mdx
+++ b/pages/features/additional-hooks.mdx
@@ -13,13 +13,13 @@ import { useValue } from 'atomic-state'
 Now instead of writing:
 
 ```jsx
-const [clicksCount] = useAtom(click)
+const [clicksCount] = useAtom(clicks)
 ```
 
 You would write:
 
 ```jsx
-const clicksCount = useValue(click)
+const clicksCount = useValue(clicks)
 ```
 
 ## `useDispatch`


### PR DESCRIPTION
atom in examples is 'clicks' not 'click'