### PR TITLE
docs: Fix typo

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ export default function Nextra({ Component, pageProps }) {
       <Head>
         <meta
           name="description"
-          content="Atomic State is a state managment library for React apps"
+          content="Atomic State is a state management library for React apps"
         />
         <meta property="og:image" content="/preview-image.jpg" />
       </Head>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -2,6 +2,6 @@ import Bleed from 'nextra-theme-docs/bleed'
 
 # Atomic State
 
-**Atomic State** is a state managent library for [React](https://reactjs.org).
+**Atomic State** is a state management library for [React](https://reactjs.org).
 
 Initially looking to build something similar to [Recoil](https://recoiljs.org/), these are the docs for the resulting library.

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # [Atomic State](https://atomic-state.com)
 
-Atomic State is a state managment library for React, inspired by Recoil.
+Atomic State is a state management library for React, inspired by Recoil.
 
 Feel free to contribute 😊

--- a/theme.config.js
+++ b/theme.config.js
@@ -7,7 +7,7 @@ export default {
     <>
       <span className="mr-2 font-extrabold hidden md:inline">Atomic State</span>
       <span className="text-gray-600 font-normal hidden md:inline">
-        A(nother) state managment library
+        A(nother) state management library
       </span>
     </>
   ),
@@ -19,11 +19,11 @@ export default {
       <meta httpEquiv="Content-Language" content="en" />
       <meta
         name="description"
-        content="Atomic State - a(nother) state managment library"
+        content="Atomic State - a(nother) state management library"
       />
       <meta
         name="og:description"
-        content="Atomic State - a(nother) state managment library"
+        content="Atomic State - a(nother) state management library"
       />
       <meta name="og:title" content="Atomic State" />
       <meta name="apple-mobile-web-app-title" content="Atomic State" />


### PR DESCRIPTION
Replaces 'managment' with 'management'